### PR TITLE
Don't add to queue if song has been played before

### DIFF
--- a/src/components/App.js
+++ b/src/components/App.js
@@ -7,7 +7,7 @@ import JoinRoom from './JoinRoom';
 import Room from './Room';
 import Header from './Header';
 import Footer from './Footer';
-import SpotifyPlayer from '../SpotifyPlayer';
+import SpotifyPlayer from './SpotifyPlayer';
 
 const history = createBrowserHistory();
 

--- a/src/components/Room.js
+++ b/src/components/Room.js
@@ -9,12 +9,10 @@ import { Grid } from 'semantic-ui-react';
 import Sidebar from './Sidebar';
 import Content from './Content';
 import NowPlaying from './NowPlaying';
-import { updateNowPlaying } from '../actions/nowPlaying';
 import { nextSong, updateQueue } from '../actions/player';
 import config from '../../config';
 
 const actions = {
-  updateNowPlaying,
   nextSong,
   updateQueue
 };
@@ -59,7 +57,6 @@ class Room extends React.Component {
       if ((currentTrack === previousTrack) && (duration === 0)) {
         return this.props.nextSong((id) => this.state.roomTable.remove(id), deviceId, this.refreshSpotifyPlayer);
       }
-      this.props.updateNowPlaying(_.get(state, 'track_window.current_track', {}));
     }).bind(this));
   }
 

--- a/src/components/SpotifyPlayer.js
+++ b/src/components/SpotifyPlayer.js
@@ -1,6 +1,6 @@
 import React from 'react';
 import _ from 'lodash';
-import { getCookie, refreshAccessToken } from './util.js';
+import { getCookie, refreshAccessToken } from '../util.js';
 
 export default class SpotifyPlayer extends React.Component {
   constructor(props) {

--- a/src/index.js
+++ b/src/index.js
@@ -1,4 +1,4 @@
- import React from 'react';
+import React from 'react';
 import { render } from 'react-dom';
 import { createStore, applyMiddleware } from 'redux';
 import thunk from 'redux-thunk';

--- a/src/reducers/context.js
+++ b/src/reducers/context.js
@@ -39,11 +39,12 @@ const context = (state = initialState, action) => {
         previouslyPlayed: state.previouslyPlayed
       };
     case PLAY_SONG_SUCCESS:
+      const newUpNext = (action.upNext.length === 0) ? state.upNext.songs : action.upNext;
       return {
         upNext: {
           loading: false,
           error: null,
-          songs: action.upNext || state.upNext.songs
+          songs: newUpNext
         },
         queue: state.queue,
         previouslyPlayed: { songs: _.concat(state.previouslyPlayed.songs, action.song) }

--- a/src/reducers/context.js
+++ b/src/reducers/context.js
@@ -14,7 +14,19 @@ import {
   NEXT_SONG_FAIL
 } from '../actions/player.js';
 
-const context = (state = { upNext: { loading: false, error: null, songs: [] }, queue: { loading: false, error: null, songs: [] } }, action) => {
+const initialState = {
+  upNext: {
+    loading: false, error: null, songs: []
+  },
+  queue: {
+    loading: false, error: null, songs: []
+  },
+  previouslyPlayed: {
+    songs: []
+  }
+};
+
+const context = (state = initialState, action) => {
   switch (action.type) {
     case PLAY_SONG:
       return {
@@ -23,7 +35,8 @@ const context = (state = { upNext: { loading: false, error: null, songs: [] }, q
           error: null,
           songs: state.upNext.songs
         },
-        queue: state.queue
+        queue: state.queue,
+        previouslyPlayed: state.previouslyPlayed
       };
     case PLAY_SONG_SUCCESS:
       return {
@@ -32,7 +45,8 @@ const context = (state = { upNext: { loading: false, error: null, songs: [] }, q
           error: null,
           songs: action.songs || state.upNext.songs
         },
-        queue: state.queue
+        queue: state.queue,
+        previouslyPlayed: { songs: _.concat(state.previouslyPlayed.songs, action.song) }
       };
     case PLAY_SONG_FAIL:
       return {
@@ -41,7 +55,8 @@ const context = (state = { upNext: { loading: false, error: null, songs: [] }, q
           error: action.error,
           songs: state.upNext.songs
         },
-        queue: state.queue
+        queue: state.queue,
+        previouslyPlayed: state.previouslyPlayed
       };
     case QUEUE_SONG:
       return {
@@ -50,7 +65,8 @@ const context = (state = { upNext: { loading: false, error: null, songs: [] }, q
           loading: true,
           error: null,
           songs: state.queue.songs
-        }
+        },
+        previouslyPlayed: state.previouslyPlayed
       };
     case QUEUE_SONG_SUCCESS:
       return {
@@ -59,7 +75,8 @@ const context = (state = { upNext: { loading: false, error: null, songs: [] }, q
           loading: false,
           error: null,
           songs: _.concat(state.queue.songs, action.song)
-        }
+        },
+        previouslyPlayed: state.previouslyPlayed
       };
     case QUEUE_SONG_FAIL:
       return {
@@ -68,7 +85,8 @@ const context = (state = { upNext: { loading: false, error: null, songs: [] }, q
           loading: false,
           error: action.error,
           songs: state.queue.songs
-        }
+        },
+        previouslyPlayed: state.previouslyPlayed
       };
     case UPDATE_QUEUE:
       return {
@@ -77,7 +95,8 @@ const context = (state = { upNext: { loading: false, error: null, songs: [] }, q
           loading: true,
           error: null,
           songs: state.queue.songs
-        }
+        },
+        previouslyPlayed: state.previouslyPlayed
       };
     case UPDATE_QUEUE_SUCCESS:
       const roomQueue = action.songs;
@@ -91,7 +110,8 @@ const context = (state = { upNext: { loading: false, error: null, songs: [] }, q
           loading: false,
           error: null,
           songs: newQueue
-        }
+        },
+        previouslyPlayed: state.previouslyPlayed
       };
     case UPDATE_QUEUE_FAIL:
       return {
@@ -100,7 +120,8 @@ const context = (state = { upNext: { loading: false, error: null, songs: [] }, q
           loading: false,
           error: action.error,
           songs: state.queue.songs
-        }
+        },
+        previouslyPlayed: state.previouslyPlayed
       };
     case NEXT_SONG:
       return {
@@ -113,7 +134,8 @@ const context = (state = { upNext: { loading: false, error: null, songs: [] }, q
           loading: true,
           error: null,
           songs: state.queue.songs
-        } : state.queue
+        } : state.queue,
+        previouslyPlayed: state.previouslyPlayed
       };
     case NEXT_SONG_SUCCESS:
       return {
@@ -126,7 +148,8 @@ const context = (state = { upNext: { loading: false, error: null, songs: [] }, q
           loading: false,
           error: null,
           songs: action.playingFromQueue ? _.slice(state.queue.songs, 1) || [] : state.queue.songs
-        }
+        },
+        previouslyPlayed: { songs: _.concat(state.previouslyPlayed.songs, action.song) }
       };
     case NEXT_SONG_FAIL:
       return {
@@ -139,7 +162,8 @@ const context = (state = { upNext: { loading: false, error: null, songs: [] }, q
           loading: false,
           error: action.error,
           songs: state.queue.songs
-        } : state.queue.songs
+        } : state.queue.songs,
+        previouslyPlayed: state.previouslyPlayed
       };
     default:
       return state;

--- a/src/reducers/context.js
+++ b/src/reducers/context.js
@@ -43,7 +43,7 @@ const context = (state = initialState, action) => {
         upNext: {
           loading: false,
           error: null,
-          songs: action.songs || state.upNext.songs
+          songs: action.upNext || state.upNext.songs
         },
         queue: state.queue,
         previouslyPlayed: { songs: _.concat(state.previouslyPlayed.songs, action.song) }

--- a/src/reducers/context.js
+++ b/src/reducers/context.js
@@ -102,7 +102,8 @@ const context = (state = initialState, action) => {
       const roomQueue = action.songs;
       const localQueue = state.queue.songs;
       const localQueueTimestamps = _.map(localQueue, 'id');
-      const newSongsInQueue = _.reject(action.songs, (song) => _.includes(localQueueTimestamps, song.id));
+      const previouslyPlayedTimestamps = _.map(state.previouslyPlayed.songs, 'id');
+      const newSongsInQueue = _.reject(action.songs, (song) => (_.includes(localQueueTimestamps, song.id) || _.includes(previouslyPlayedTimestamps, song.id)));
       const newQueue = _.sortBy(_.concat(localQueue, newSongsInQueue), 'id');
       return {
         upNext: state.upNext,

--- a/src/reducers/index.js
+++ b/src/reducers/index.js
@@ -5,6 +5,6 @@ import context from './context';
 
 const collaborativeQueueApp = combineReducers({
   songs, nowPlaying, context
-})
+});
 
 export default collaborativeQueueApp;

--- a/src/reducers/nowPlaying.js
+++ b/src/reducers/nowPlaying.js
@@ -1,12 +1,12 @@
 import {
   UPDATE_NOW_PLAYING
-} from '../actions/nowPlaying.js';
+} from '../actions/nowPlaying';
 import { reduceSpotifyTrack } from '../util';
 
 const nowPlaying = (state = {}, action) => {
   switch (action.type) {
     case UPDATE_NOW_PLAYING:
-      return reduceSpotifyTrack(action.song);
+      return action.song;
     default:
       return state;
   }


### PR DESCRIPTION
Since a song is removed from the db only when the user that added it played it, there's a chance that when the queue is updated, an old song already heard by you (but not deleted because it wasn't heard by the guy that added it) is re-added in the queue. Since the queue is sorted by time, the song would show up at the top.

This prevents that by checking the `id`s (timestamp) of the queue'd song and not adding it if it has been heard already

Also opens up the opportunity to export your session as a Spotify playlist